### PR TITLE
update readme badges

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,16 @@
+# Run unit test coverage on each master merge for display in a README badge
+name: Coverage
+on:
+  push:
+    branches: [master]
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+      - run: mvn test jacoco:report coveralls:report -D repoToken=${{ secrets.coveralls_repo_token }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,17 @@
+# Run unit tests on each master merge for display in a README badge and on each PR as a requirement for merging.
+name: Unit tests
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+      - run: mvn test

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 # Blueflood
 
-[![Build Status](https://travis-ci.org/rackerlabs/blueflood.svg?branch=master)](https://travis-ci.org/rackerlabs/blueflood)
-[![Coveralls](https://coveralls.io/repos/github/rackerlabs/blueflood/badge.svg?branch=master)](https://github.com/rackerlabs/blueflood/releases)
-[![Releases](http://img.shields.io/badge/rax-release-v1.0.1956.svg)](https://coveralls.io/github/mmi-cookbooks/metrics-repose?branch=master)
+[![Unit tests](https://github.com/rax-maas/blueflood/actions/workflows/unit-test.yml/badge.svg?branch=master)](https://github.com/rax-maas/blueflood/actions/workflows/unit-test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/rax-maas/blueflood/badge.svg?branch=master)](https://coveralls.io/github/rax-maas/blueflood?branch=master)
 [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 [Discuss](https://groups.google.com/forum/#!forum/blueflood-discuss) - [Code](http://github.com/rackerlabs/blueflood) - [Site](http://blueflood.io)
@@ -83,4 +82,3 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
    http://www.apache.org/licenses/LICENSE-2.0 
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-

--- a/blueflood-integration-tests/pom.xml
+++ b/blueflood-integration-tests/pom.xml
@@ -122,14 +122,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.2.201409121644</version>
         <executions>
-          <execution>
-            <id>prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
           <execution>
             <id>prepare-it-agent</id>
             <phase>pre-integration-test</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
             <skipDocker>true</skipDocker>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.2.201409121644</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -187,16 +192,21 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.1.0</version>
-        <configuration>
-          <jacocoReports>
-            <jacocoReport>blueflood-core/target/site/jacoco/jacoco.xml</jacocoReport>
-            <jacocoReport>blueflood-integration-tests/target/site/jacoco-it/jacoco.xml</jacocoReport>
-            <jacocoReport>blueflood-http/target/site/jacoco/jacoco.xml</jacocoReport>
-          </jacocoReports>
-        </configuration>
       </plugin>
 
-
+      <!-- Jacoco coverage for surefire tests in all submodules. Use jacoco:report to build reports after tests. -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -209,7 +219,7 @@
       </plugin>
     </plugins>
   </reporting>
-  
+
   <profiles>
     <profile>
       <id>dev</id>


### PR DESCRIPTION
I'm revamping the readme, and the first thing in it is some very
out-of-date badges. This cleans them up a little and makes them work
with some basic github workflows that'll be expanded later.

In doing so, I found that code coverage is only running for
integration tests, which probably isn't right. I added it for unit
tests, as well, and the workflow is doing only unit test coverage
right now. In the future, we'll need to be careful to keep the unit
test and integration test coverage separate.