### PR TITLE
removes test jar building

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/InMemoryMetadataIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/InMemoryMetadataIO.java
@@ -1,4 +1,4 @@
-package com.rackspacecloud.blueflood.utils;
+package com.rackspacecloud.blueflood.io;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.HashBasedTable;
@@ -62,4 +62,3 @@ public class InMemoryMetadataIO implements MetadataIO, CassandraUtilsIO {
         backingTable.clear();
     }
 }
-

--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/IncomingMetricMetadataAnalyzerTest.java
@@ -7,7 +7,7 @@ import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.service.IncomingMetricMetadataAnalyzer;
 import com.rackspacecloud.blueflood.types.*;
-import com.rackspacecloud.blueflood.utils.InMemoryMetadataIO;
+import com.rackspacecloud.blueflood.io.InMemoryMetadataIO;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import com.rackspacecloud.blueflood.utils.Util;
 import junit.framework.Assert;

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -40,13 +40,6 @@
     </dependency>
 
     <dependency>
-      <artifactId>blueflood-core</artifactId>
-      <groupId>com.rackspacecloud</groupId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-    </dependency>
-
-    <dependency>
       <artifactId>blueflood-elasticsearch</artifactId>
       <groupId>com.rackspacecloud</groupId>
       <version>${project.version}</version>

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
@@ -26,7 +26,7 @@ import com.rackspacecloud.blueflood.io.datastax.DCassandraUtilsIO;
 import com.rackspacecloud.blueflood.io.IntegrationTestBase;
 import com.rackspacecloud.blueflood.types.Locator;
 import com.rackspacecloud.blueflood.types.MetricMetadata;
-import com.rackspacecloud.blueflood.utils.InMemoryMetadataIO;
+import com.rackspacecloud.blueflood.io.InMemoryMetadataIO;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;

--- a/pom.xml
+++ b/pom.xml
@@ -159,20 +159,6 @@
         </executions>
       </plugin>
 
-      <!-- packages up the test files. -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
At one point, some few test classes were shared between core and http
modules and the integration tests. Those classes (with one exception,
addressed here) were moved to main source to avoid having to manage
test jars and dependencies. There's no need to build them anymore.