### PR TITLE
makes module names conform to the same pattern

### DIFF
--- a/blueflood-all/pom.xml
+++ b/blueflood-all/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <name>blueflood-all</name>
+  <name>Blueflood Artifact Assembly</name>
   <artifactId>blueflood-all</artifactId>
   <packaging>jar</packaging>
 

--- a/blueflood-integration-tests/pom.xml
+++ b/blueflood-integration-tests/pom.xml
@@ -28,7 +28,7 @@
 
   <artifactId>blueflood-integration-tests</artifactId>
 
-  <name>Module with All Integration Tests</name>
+  <name>Blueflood Integration Tests</name>
   <properties>
     <cassandra.listenAddress>127.0.0.1</cassandra.listenAddress>
     <cassandra.plugin.version>2.1.7-1</cassandra.plugin.version>


### PR DESCRIPTION
The blueflood-all and blueflood-integration-tests modules have names
that are notably different from the rest. This makes them conform to
the standard naming pattern shared by the other modules.a

Before:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Blueflood 2.1.0-SNAPSHOT:
[INFO]
[INFO] Blueflood .......................................... SUCCESS [  0.192 s]
[INFO] Blueflood Core Engine .............................. SUCCESS [  0.011 s]
[INFO] Blueflood Elasticsearch Indexer and Discovery ...... SUCCESS [  0.007 s]
[INFO] Blueflood HTTP Ingestion and Querying .............. SUCCESS [  0.004 s]
[INFO] Blueflood Rollup Cloudfiles Exporter ............... SUCCESS [  0.005 s]
[INFO] Blueflood Out-of-band Rollup Tools ................. SUCCESS [  0.016 s]
[INFO] Module with All Integration Tests .................. SUCCESS [  0.070 s]
[INFO] blueflood-all ...................................... SUCCESS [  0.005 s]
[INFO] ------------------------------------------------------------------------
```

After:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Blueflood 2.1.0-SNAPSHOT:
[INFO]
[INFO] Blueflood .......................................... SUCCESS [  0.184 s]
[INFO] Blueflood Core Engine .............................. SUCCESS [  0.048 s]
[INFO] Blueflood Elasticsearch Indexer and Discovery ...... SUCCESS [  0.014 s]
[INFO] Blueflood HTTP Ingestion and Querying .............. SUCCESS [  0.014 s]
[INFO] Blueflood Rollup Cloudfiles Exporter ............... SUCCESS [  0.006 s]
[INFO] Blueflood Out-of-band Rollup Tools ................. SUCCESS [  0.010 s]
[INFO] Blueflood Integration Tests ........................ SUCCESS [  0.085 s]
[INFO] Blueflood Artifact Assembly ........................ SUCCESS [  0.012 s]
[INFO] ------------------------------------------------------------------------
```