### PR TITLE
improves blueflood start script

### DIFF
--- a/bin/blueflood-start.sh
+++ b/bin/blueflood-start.sh
@@ -7,7 +7,7 @@
 #
 
 # directory where the script is located
-SCRIPTDIR=`pwd`/`dirname $0`  
+SCRIPTDIR=`pwd`/`dirname $0`
 
 # top level source directory
 TOPDIR=$SCRIPTDIR/..
@@ -18,15 +18,18 @@ if [ ! -d $TOPDIR/blueflood-all/target ]; then
     exit 1
 fi
 
-JAVA=/usr/bin/java
+dbg=""
+[ "$DEBUG" = true ] && dbg="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
 
-$JAVA \
-        -Dblueflood.config=file:///$TOPDIR/demo/local/config/blueflood.conf \
-        -Dlog4j.configuration=file:///$TOPDIR/demo/local/config/blueflood-log4j.properties \
+java \
+        $dbg \
+        -Dblueflood.config=file:///$TOPDIR/contrib/getting-started/blueflood.properties \
+        -Dlog4j.configuration=file:///$TOPDIR/contrib/getting-started/log4j.properties \
         -Xms1G \
         -Xmx1G \
         -Dcom.sun.management.jmxremote.authenticate=false \
         -Dcom.sun.management.jmxremote.ssl=false \
         -Djava.rmi.server.hostname=localhost \
         -Dcom.sun.management.jmxremote.port=9180 \
-        -classpath $TOPDIR/blueflood-all/target/blueflood-all-*-jar-with-dependencies.jar com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1
+        -classpath $TOPDIR/blueflood-all/target/blueflood-all-*-jar-with-dependencies.jar \
+        com.rackspacecloud.blueflood.service.BluefloodServiceStarter 2>&1


### PR DESCRIPTION
Two changes:

1. Don't force use of system java. My system java is too new, and I
have a separate java installation that I add to JAVA_HOME and PATH
when I need to do blueflood things. It should just run java from the
PATH.

2. Adds a DEBUG flag that'll let you connect a remote debugger to the
JVM. This is referenced in a Development guide on the wiki.