### PR TITLE
adds "getting started" configs

### DIFF
--- a/contrib/getting-started/blueflood.properties
+++ b/contrib/getting-started/blueflood.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CLUSTER_NAME=Demo Cluster
+CASSANDRA_HOSTS=localhost:9042
+CASSANDRA_DRIVER=datastax
+INGESTION_MODULES=com.rackspacecloud.blueflood.service.HttpIngestionService
+QUERY_MODULES=com.rackspacecloud.blueflood.service.HttpQueryService
+DISCOVERY_MODULES=com.rackspacecloud.blueflood.io.ElasticIO

--- a/contrib/getting-started/log4j.properties
+++ b/contrib/getting-started/log4j.properties
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %m%n
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
+log4j.logger.org.apache.http.client.protocol=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.org.apache.http.impl=INFO
+log4j.logger.org.apache.http.headers=INFO
+log4j.rootLogger=INFO, console


### PR DESCRIPTION
Blueflood needs some basic configuration to run. Its default config
values don't let it start. I should maybe fix that. As it is, we need
some basic config files so that anyone can easily get Blueflood
running without having to think about the details of configuring a new
instance. This adds minimal configs that let the app start and log to
stdout.

Various places in the docs refered to a basic config, and some used
the config files from the "demo" directory. I think it's better to
have dedicated, minimal configs aimed specifically at a first
startup. The demo configs could fluctuate over time if the demo app
needs to adapt to different uses. I've updated all the references I've
found to point at these, new configs.