### PR TITLE
removes 'all-modules' profile

### DIFF
--- a/bin/blueflood-start.sh
+++ b/bin/blueflood-start.sh
@@ -3,7 +3,7 @@
 #
 # This is a simple script that can be used to start blueflood service.
 # To run this, you must have built the blueflood package by running:
-#     mvn clean package -P all-modules
+#     mvn clean package
 #
 
 # directory where the script is located
@@ -14,7 +14,7 @@ TOPDIR=$SCRIPTDIR/..
 
 if [ ! -d $TOPDIR/blueflood-all/target ]; then
     echo "Error: blueflood-all/target directory does not exist. Please run build:"
-    echo "    mvn clean package -P all-modules"
+    echo "    mvn clean package"
     exit 1
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <module>blueflood-cloudfiles</module>
     <module>blueflood-rollupTools</module>
     <module>blueflood-integration-tests</module>
+    <module>blueflood-all</module>
   </modules>
 
   <description>
@@ -216,12 +217,6 @@
       <properties>
         <skip.unit.tests>true</skip.unit.tests>
       </properties>
-    </profile>
-    <profile>
-      <id>all-modules</id>
-      <modules>
-        <module>blueflood-all</module>
-      </modules>
     </profile>
     <profile>
       <id>logstash-support</id>


### PR DESCRIPTION
The only thing this profile does is add the `blueflood-all` submodule
to the build, which builds the uber jar in the package phase.  I see
no reason to have this be a special step that has to be done each time
you want to build the whole project.  This makes it a normal submodule
that's always in the build. Now a `mvn package` alone will build the
uber-jar, as you might expect from any given maven project.