### PR TITLE
moves common test dependencies to top level

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -30,10 +30,6 @@
   <name>Blueflood Core Engine</name>
   <artifactId>blueflood-core</artifactId>
 
-  <properties>
-    <powermock.version>1.6.4</powermock.version>
-  </properties>
-
   <build>
     <plugins>
       <!-- bundle -->
@@ -226,43 +222,15 @@
 
     <!-- testing dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-    </dependency>
-
-    <dependency>
       <groupId>bigml</groupId>
       <artifactId>histogram</artifactId>
       <version>3.2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>3.18.2-GA</version>
         <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.tempus-fugit</groupId>

--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -90,10 +90,6 @@
       <artifactId>httpmime</artifactId>
       <version>4.3.1</version>
     </dependency>
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -88,39 +88,6 @@
 
       <!-- testing dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.4</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.4</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.github.tlrx</groupId>
       <artifactId>elasticsearch-test</artifactId>
       <version>1.2.1</version>

--- a/blueflood-integration-tests/pom.xml
+++ b/blueflood-integration-tests/pom.xml
@@ -54,12 +54,6 @@
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
-
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,8 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>4.13.2</version>
         <scope>test</scope>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -82,12 +81,59 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.10.19</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>1.6.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>1.6.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>4.0.44.Final</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <!-- Standardized test dependencies available to all modules. It's better to put them here than to repeat them in
+    each submodule's pom. -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+    </dependency>
+  </dependencies>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
Junit, Powermock, Hamcrest, and Mockito are libraries that should
always be there in any module. There's no reason to repeat them,
though. Just set them in the parent pom, and the children will inherit
them. Otherwise, you'll end up with different submodules having
different combinations of the dependencies, and nobody wants to deal
with that.

Along the way, this deals with some other problems. It upgrades to the
latest junit 4 so that I can use assertThrows() in tests. It also
removes mockito-all in favor of mockito-core. The "all" variant has
hamcrest nested inside it, and they're a different version than the
other hamcrest dependencies, causing some weird internal errors.