### PR TITLE
improve existing Elasticsearch IT

### DIFF
--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/BaseElasticTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/BaseElasticTest.java
@@ -107,22 +107,4 @@ public abstract class BaseElasticTest {
         }
         return metrics;
     }
-
-    protected void verifyResults(List<MetricName> results, Set<String> expectedResults) {
-        Set<String> formattedResults = formatForComparision(results);
-        assertTrue("Expected results does not contain all of api results", expectedResults.containsAll(formattedResults));
-        assertTrue("API results does not contain all of expected results", formattedResults.containsAll(expectedResults));
-        Assert.assertEquals("Invalid total number of results", expectedResults.size(), results.size());
-    }
-
-    protected Set<String> formatForComparision(List<MetricName> results) {
-        final String DELIMITER = "|";
-
-        Set<String> formattedResults = new HashSet<String>();
-        for (MetricName metricName : results) {
-            formattedResults.add(metricName.getName() + DELIMITER + metricName.isCompleteName());
-        }
-
-        return formattedResults;
-    }
 }


### PR DESCRIPTION
Some tests don't actually assert anything. Some aren't annotated as
tests. There's also a branch of code, related to wildcards, that isn't
covered by any existing test. This cleans those things up so that this
integration test is stricter than before.