### PR TITLE
Es rest helper instrumentation

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -125,6 +125,7 @@ public enum CoreConfig implements ConfigDefaults {
     GRAPHITE_HOST(""),
     GRAPHITE_PORT("2003"),
     GRAPHITE_PREFIX("unconfiguredNode.metrics."),
+    GRAPHITE_REPORT_PERIOD_SECONDS("30"),
 
     INGEST_MODE("true"),
     ROLLUP_MODE("true"),

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
@@ -110,7 +110,7 @@ public class Metrics {
                     .prefixedWith(config.getStringProperty(CoreConfig.GRAPHITE_PREFIX))
                     .build(graphite);
 
-            reporter.start(30l, TimeUnit.SECONDS);
+            reporter.start(config.getIntegerProperty(CoreConfig.GRAPHITE_REPORT_PERIOD_SECONDS), TimeUnit.SECONDS);
         } else {
             reporter = null;
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
@@ -159,4 +159,12 @@ public class Metrics {
     public static Counter counter(Class kls, String... names) {
         return getRegistry().counter(MetricRegistry.name(kls, names));
     }
+
+    public static void registerGauge(Class kls, Gauge gauge, String ...names) {
+        // MetricRegistry does not offer getOrAdd wrapper for Gauge
+        String name = MetricRegistry.name(kls, names);
+        if(!getRegistry().getGauges().containsKey(name)) {
+            getRegistry().register(name, gauge);
+        }
+    }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/utils/Metrics.java
@@ -161,10 +161,7 @@ public class Metrics {
     }
 
     public static void registerGauge(Class kls, Gauge gauge, String ...names) {
-        // MetricRegistry does not offer getOrAdd wrapper for Gauge
         String name = MetricRegistry.name(kls, names);
-        if(!getRegistry().getGauges().containsKey(name)) {
-            getRegistry().register(name, gauge);
-        }
+        getRegistry().register(name, gauge);
     }
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
@@ -552,4 +552,19 @@ public class ElasticsearchRestHelper {
         this.pendingPoolSize.update(poolStats.getPending());
         this.leasedPoolSize.update(poolStats.getLeased());
     }
+
+    @VisibleForTesting
+    public Histogram getAvailablePoolSize() {
+        return availablePoolSize;
+    }
+
+    @VisibleForTesting
+    public Histogram getPendingPoolSize() {
+        return pendingPoolSize;
+    }
+
+    @VisibleForTesting
+    public Histogram getLeasedPoolSize() {
+        return leasedPoolSize;
+    }
 }

--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
@@ -1,7 +1,6 @@
 package com.rackspacecloud.blueflood.io;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
 import com.google.common.annotations.VisibleForTesting;
 import com.rackspacecloud.blueflood.service.Configuration;
 import com.rackspacecloud.blueflood.service.CoreConfig;
@@ -53,25 +52,14 @@ public class ElasticsearchRestHelper {
        put("index", counter(getClass(), "index Error"));
     }};
 
+    private static final ElasticsearchRestHelper INSTANCE = new ElasticsearchRestHelper();
+
     /**
      * Gets an instance of the ES rest helper for use in main source.
      * @return
      */
     public static ElasticsearchRestHelper getInstance() {
-        // TODO: To match the rest of the project, this should be a static singleton. There seems to be an HTTP
-        // connection pool in use here, which is pointless if an instance of this isn't shared by many consumers. On the
-        // other hand, making this a singleton could affect performance dramatically if the pool hasn't already been
-        // tuned to support the workload, so don't change it without some testing.
-        return new ElasticsearchRestHelper();
-    }
-
-    /**
-     * Gets a fresh instance instead of the static singleton. For use in tests so that a test can change the app
-     * configuration and then get a new instance based on that configuration.
-     */
-    @VisibleForTesting
-    public static ElasticsearchRestHelper getConfigurableInstance() {
-        return new ElasticsearchRestHelper();
+        return INSTANCE;
     }
 
     private ElasticsearchRestHelper(){

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
@@ -1,0 +1,68 @@
+package com.rackspacecloud.blueflood.io;
+
+import com.codahale.metrics.Histogram;
+import com.github.tlrx.elasticsearch.test.EsSetup;
+import com.rackspacecloud.blueflood.utils.Metrics;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.rackspacecloud.blueflood.utils.Metrics.counter;
+
+
+public class ElasticsearchRestHelperTest {
+  private static EsSetup esSetup;
+  protected ElasticsearchRestHelper helper;
+
+  @BeforeClass
+  public static void setupEs() {
+    esSetup = new EsSetup();
+  }
+
+  @Before
+  public void setup() {
+    esSetup.execute(EsSetup.deleteAll());
+    resetMetricRegistry();
+    helper = ElasticsearchRestHelper.getInstance();
+    Assert.assertEquals(3, Metrics.getRegistry().getHistograms().size());
+    // No histograms recorded yet prior to test run
+    assertConnectionCounts(0);
+  }
+
+  @Test
+  public void testElasticsearchGet_recordsPoolSizeMetrics() throws IOException {
+    helper.refreshIndex("foo");
+    assertConnectionCounts(1);
+  }
+
+  @Test
+  public void testElasticsearchPost_recordsPoolSizeMetrics() throws IOException {
+    helper.fetchEvents("fooTenant", new HashMap<>());
+    assertConnectionCounts(1);
+  }
+
+  @Test
+  public void testElasticsearchPostErrors_recordsMetric() throws IOException {
+    esSetup.terminate();
+    Assert.assertTrue(counter(ElasticsearchRestHelper.class, "fetchEvents Error").getCount() == 0);
+    helper.fetchEvents("fooTenant", new HashMap<>());
+    Assert.assertTrue(counter(ElasticsearchRestHelper.class, "fetchEvents Error").getCount() > 0);
+  }
+
+  private void assertConnectionCounts(int expectedCount) {
+    for (Map.Entry<String, Histogram> histogramEntry : Metrics.getRegistry().getHistograms().entrySet()) {
+      Assert.assertEquals(expectedCount, histogramEntry.getValue().getCount());
+    }
+  }
+
+  private void resetMetricRegistry() {
+    for (String metricName : Metrics.getRegistry().getMetrics().keySet()) {
+      Metrics.getRegistry().remove(metricName);
+    }
+  }
+}

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
@@ -7,7 +7,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +19,10 @@ import java.util.HashMap;
 import java.util.Set;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.powermock.api.mockito.PowerMockito.*;
 
@@ -53,9 +55,9 @@ public class ElasticsearchRestHelperTest {
     helper = ElasticsearchRestHelper.getInstance();
     // then
     Set<String> registeredGauges = Metrics.getRegistry().getGauges().keySet();
-    assertTrue(registeredGauges.contains(name(ElasticsearchRestHelper.class, "Available Connections")));
-    assertTrue(registeredGauges.contains(name(ElasticsearchRestHelper.class, "Pending Connections")));
-    assertTrue(registeredGauges.contains(name(ElasticsearchRestHelper.class, "Leased Connections")));
+    assertThat(registeredGauges, hasItem(name(ElasticsearchRestHelper.class, "Available Connections")));
+    assertThat(registeredGauges, hasItem(name(ElasticsearchRestHelper.class, "Pending Connections")));
+    assertThat(registeredGauges, hasItem(name(ElasticsearchRestHelper.class, "Leased Connections")));
   }
 
   @Test
@@ -63,10 +65,10 @@ public class ElasticsearchRestHelperTest {
     // Ensure Error counter is 0 prior to failures simulation
     helper = ElasticsearchRestHelper.getInstance();
     Counter fetchEventsErrorCounter = helper.getErrorCounters().get("fetchEvents");
-    Assert.assertEquals(0, fetchEventsErrorCounter.getCount());
+    assertThat(fetchEventsErrorCounter.getCount(), equalTo(0L));
     when(mockHttpClient.execute(any())).thenThrow(new IOException("test exception"));
     helper.fetchEvents("fooErrorTenant", new HashMap<>());
-    assertTrue(fetchEventsErrorCounter.getCount() > 0);
+    assertThat(fetchEventsErrorCounter.getCount(), greaterThan(0L));
   }
 
 

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
@@ -50,7 +50,7 @@ public class ElasticsearchRestHelperTest {
   @Test
   public void testConstructor_registersHttpConnectionStatsGauges() {
     // when
-    helper = ElasticsearchRestHelper.getConfigurableInstance();
+    helper = ElasticsearchRestHelper.getInstance();
     // then
     Set<String> registeredGauges = Metrics.getRegistry().getGauges().keySet();
     assertTrue(registeredGauges.contains(name(ElasticsearchRestHelper.class, "Available Connections")));
@@ -61,7 +61,7 @@ public class ElasticsearchRestHelperTest {
   @Test
   public void testElasticsearchPostErrors_incrementsErrorCounter() throws IOException {
     // Ensure Error counter is 0 prior to failures simulation
-    helper = ElasticsearchRestHelper.getConfigurableInstance();
+    helper = ElasticsearchRestHelper.getInstance();
     Counter fetchEventsErrorCounter = helper.getErrorCounters().get("fetchEvents");
     Assert.assertEquals(0, fetchEventsErrorCounter.getCount());
     when(mockHttpClient.execute(any())).thenThrow(new IOException("test exception"));

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
@@ -1,63 +1,82 @@
 package com.rackspacecloud.blueflood.io;
 
-import com.codahale.metrics.Histogram;
-import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.utils.Metrics;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import static com.rackspacecloud.blueflood.utils.Metrics.counter;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.powermock.api.mockito.PowerMockito.*;
 
-
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
+@PrepareForTest(fullyQualifiedNames = "org.apache.http.impl.client.*")
 public class ElasticsearchRestHelperTest {
-  private static EsSetup esSetup;
-  protected ElasticsearchRestHelper helper;
 
-  @BeforeClass
-  public static void setupEs() {
-    esSetup = new EsSetup();
-  }
+  private ElasticsearchRestHelper helper;
+  private HttpClientBuilder mockBuilder = mock(HttpClientBuilder.class);
+  private CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
+  private CloseableHttpResponse mockHttpResponse = mock(CloseableHttpResponse.class);
+  private StatusLine statusLine = mock(StatusLine.class);
 
   @Before
-  public void setup() {
-    esSetup.execute(EsSetup.deleteAll());
+  public void setup() throws IOException {
+    // HttpClient dependency is nested inside pool manager build logic.
+    // Mocking Http response requires mocking multiple instances of Apache http client resources.
+    mockStatic(HttpClients.class);
+    when(HttpClients.custom()).thenReturn(mockBuilder);
+    when(mockBuilder.setConnectionManager(any())).thenReturn(mockBuilder);
+    when(mockBuilder.build()).thenReturn(mockHttpClient);
+    when(mockHttpResponse.getStatusLine()).thenReturn(statusLine);
+
     resetMetricRegistry();
     helper = ElasticsearchRestHelper.getInstance();
-    Assert.assertEquals(3, Metrics.getRegistry().getHistograms().size());
+    assertEquals(3, Metrics.getRegistry().getHistograms().size());
     // No histograms recorded yet prior to test run
     assertConnectionCounts(0);
   }
 
   @Test
-  public void testElasticsearchGet_recordsPoolSizeMetrics() throws IOException {
+  public void testElasticsearchGet_recordsPoolSizeMetrics() throws Exception {
+    when(mockHttpClient.execute(any())).thenReturn(mockHttpResponse);
     helper.refreshIndex("foo");
     assertConnectionCounts(1);
   }
 
   @Test
   public void testElasticsearchPost_recordsPoolSizeMetrics() throws IOException {
+    when(mockHttpClient.execute(any())).thenReturn(mockHttpResponse);
     helper.fetchEvents("fooTenant", new HashMap<>());
     assertConnectionCounts(1);
   }
 
   @Test
-  public void testElasticsearchPostErrors_recordsMetric() throws IOException {
-    esSetup.terminate();
-    Assert.assertTrue(counter(ElasticsearchRestHelper.class, "fetchEvents Error").getCount() == 0);
-    helper.fetchEvents("fooTenant", new HashMap<>());
+  public void testElasticsearchPostErrors_incrementsErrorCounter() throws IOException {
+    // Ensure Error counter is 0 prior to failures simulation
+    Assert.assertEquals(0, counter(ElasticsearchRestHelper.class, "fetchEvents Error").getCount());
+    when(mockHttpClient.execute(any())).thenThrow(new IOException("test exception"));
+    helper.fetchEvents("fooErrorTenant", new HashMap<>());
     Assert.assertTrue(counter(ElasticsearchRestHelper.class, "fetchEvents Error").getCount() > 0);
   }
 
   private void assertConnectionCounts(int expectedCount) {
-    for (Map.Entry<String, Histogram> histogramEntry : Metrics.getRegistry().getHistograms().entrySet()) {
-      Assert.assertEquals(expectedCount, histogramEntry.getValue().getCount());
-    }
+    assertEquals(expectedCount, helper.getAvailablePoolSize().getCount());
+    assertEquals(expectedCount, helper.getLeasedPoolSize().getCount());
+    assertEquals(expectedCount, helper.getPendingPoolSize().getCount());
   }
 
   private void resetMetricRegistry() {

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
@@ -67,7 +67,7 @@ public class ElasticIOIntegrationTest extends BaseElasticTest {
 
     @Before
     public void setup() throws Exception {
-        helper = ElasticsearchRestHelper.getConfigurableInstance();
+        helper = ElasticsearchRestHelper.getInstance();
         tearDown();
 
         elasticIO = new ElasticIO(helper);

--- a/blueflood-integration-tests/src/integration-test/resources/blueflood.properties
+++ b/blueflood-integration-tests/src/integration-test/resources/blueflood.properties
@@ -16,3 +16,7 @@ CORS_ALLOWED_MAX_AGE=6000
 # to getting TimeoutException. This is done here because it needs to be before
 # RollupHandler is instantiated.
 ROLLUP_ON_READ_TIMEOUT_IN_SECONDS=20
+# Integration Tests use Embedded Elasticsearch Server with default 9200 port.
+# ElasticsearchRestHelper supports multi node cluster configuration to load balance requests to ES.
+# But tests are limited to single node and hence the override here
+ELASTICSEARCH_HOST_FOR_REST_CLIENT=127.0.0.1:9200


### PR DESCRIPTION
Adds instrumentation for Elasticsearch Http client pool stats
Added ElasticsearchRestHelperTest test class with tests limited to instrumentation code. Test class needs further unit tests to assert round robin retries, max retry attempt etc scenarios.
Also introduced a config property to customize graphite metrics flush interval to test infrequent metrics ingestion on local setup.
Below is a sample Grafana Histogram graph with the new metrics included in this PR.
<img width="1436" alt="Screen Shot 2022-07-22 at 11 06 00 AM" src="https://user-images.githubusercontent.com/4536063/180878354-85ada071-f4f3-434c-a343-3dbda0567fa5.png">

