### PR TITLE
make init-es.sh work outside bash

### DIFF
--- a/blueflood-elasticsearch/src/main/resources/init-es.sh
+++ b/blueflood-elasticsearch/src/main/resources/init-es.sh
@@ -33,7 +33,7 @@ if [ $ES_USERNAME ] && [ $ES_PASSWD ]; then
 fi
 
 # Using this in the checkfile function allows us to run this script from any directory
-ABSOLUTE_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+ABSOLUTE_PATH=$(cd `dirname "$0"` && pwd)
 function checkFile
 {
   echo checking $1.


### PR DESCRIPTION
Many Docker images are built on lightweight linux distros that don't
include bash. The eclipse-temurin image that provides a JDK is one
example. To run a script like this on that kind of image, it can't use
any exclusive bash-isms. The script just has one, small issue: it uses
the `BASH_SOURCE` env variable. An almost identical replacement for
`${BASH_SOURCE[0]}` is `$0`, and it should work fine for us. For
further details see https://stackoverflow.com/a/35006505.