### PR TITLE
improve docker entrypoint script

### DIFF
--- a/contrib/blueflood-docker/README.md
+++ b/contrib/blueflood-docker/README.md
@@ -18,6 +18,8 @@ Here's the list of ENV variables and their description.
 | ----- | ------- | --------- |
 | CASSANDRA_HOST | IP address of Cassandra seed. (Required) | null |
 | ELASTICSEARCH_HOST | IP address of Elasticsearch node. (Required) | null |
+| DEBUG_JAVA | Whether to enable remote JVM debugging on port 5005 | false |
+| DEBUG_JAVA_SUSPEND | Whether to suspend JVM startup until a debugger attaches to the debug port | false |
 | MAX_ROLLUP_READ_THREADS | Maximum number of read threads participating in rolling up the metrics | 20 |
 | MAX_ROLLUP_WRITE_THREADS | Maximum number of write threads participating in rolling up the metrics | 5 |
 | MAX_CASSANDRA_CONNECTIONS | Maximum number of connections with each Cassandra node | 70 |


### PR DESCRIPTION
A few small changes to make the script better.

1. Cassandra may be listening on port 9160 for thrift (old style) or
9042 for cqlsh (new style) connections.

2. If ROLLUP_KEYSPACE wasn't set, it would make the cqlsh init script
invalid by replacing all occurrences of the keyspace "DATA" with "".

3. Assuming java is installed at /usr/bin/java makes the image
brittle. Let it search the PATH, the way it's designed to.

4. For dev and debugging purposes, it's nice to be able to attach a
remote debugger to blueflood when it's running. A couple of env vars
added to the script let users enable remote JVM debugging on demand.