### PR TITLE
update base image in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Important build profiles to know about:
 Blueflood's main artifact is an ['uber jar'](http://stackoverflow.com/questions/11947037/what-is-an-uber-jar), produced
 by the [`blueflood-all` module](blueflood-all/pom.xml).
 
+After compiling, you can also build a Docker image with `mvn docker:build`. See
+[blueflood-docker](contrib/blueflood-docker) for the Docker-related files.
+
 ### Running
 
 You can easily build a ready-to-run Blueflood jar from source:

--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -1,13 +1,18 @@
-FROM java:8
+FROM eclipse-temurin:8
 
 MAINTAINER gaurav.bajaj@rackspace.com
+MAINTAINER ryan.stewart@rackspace.com
 
-RUN apt-get update
-RUN apt-get install -y netcat
-RUN apt-get install -y git
-RUN apt-get install -y python python-dev python-pip python-virtualenv && \
+RUN apt-get update && apt-get install -y \
+    git \
+    netcat \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-virtualenv && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install cqlsh==4.1.1
+
+RUN pip install cqlsh==6.0.0
 
 COPY ES-Setup /ES-Setup
 COPY load.cdl /blueflood.cdl


### PR DESCRIPTION
The `java` base image is deprecated. `eclipse-temurin` is one viable
alternative for apps based on Java 8. This changes to that image. The
newer image doesn't have the old python 2 packages available, so I had
to update to python 3. Then cqlsh 4.1.1 (used in the container startup
to initialize the database) didn't work, so I updated it to a newer
version which should work all the way up to cassandra 4, at least.