### PR TITLE
make 'getting started' config more complete

### DIFF
--- a/contrib/getting-started/blueflood.properties
+++ b/contrib/getting-started/blueflood.properties
@@ -15,8 +15,24 @@
 # limitations under the License.
 
 CLUSTER_NAME=Demo Cluster
-CASSANDRA_HOSTS=localhost:9042
+
+# You can use Datastax on the CQL port ...
 CASSANDRA_DRIVER=datastax
+CASSANDRA_HOSTS=localhost:9042
+
+# ... or Astyanax on the thrift port, but thrift is removed in Cassandra 4.0.
+# You may have to 'nodetool enablethrift', too, depending on the version.
+#CASSANDRA_DRIVER=astyanax
+#CASSANDRA_HOSTS=localhost:9160
+
 INGESTION_MODULES=com.rackspacecloud.blueflood.service.HttpIngestionService
 QUERY_MODULES=com.rackspacecloud.blueflood.service.HttpQueryService
 DISCOVERY_MODULES=com.rackspacecloud.blueflood.io.ElasticIO
+
+# This enables the indexing that powers the /v2.0/{tenantId}/metric_name/search endpoint.
+ENABLE_TOKEN_SEARCH_IMPROVEMENTS=true
+# Token search improvements needs the token discovery module:
+TOKEN_DISCOVERY_MODULES=com.rackspacecloud.blueflood.io.ElasticTokensIO
+
+# Event ingestion needs the event module:
+EVENTS_MODULES=com.rackspacecloud.blueflood.io.EventElasticSearchIO


### PR DESCRIPTION
As I worked with a basic blueflood started with this config, I found
some features didn't work properly because some additional modules
need to be turned on to support them.

This sets the token discovery module and associated feature flag so
that individual tokens get indexed on ingestion (tokens of com.foo.bar
are like com, com.foo, and com.foo.bar).

It also sets the events module, which enables the /events endpoint,
where not-exactly-time series data can be stored.