### PR TITLE
resolve tempus fujit snapshot version

### DIFF
--- a/blueflood-core/pom.xml
+++ b/blueflood-core/pom.xml
@@ -235,7 +235,7 @@
     <dependency>
       <groupId>com.google.code.tempus-fugit</groupId>
       <artifactId>tempus-fugit</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
I originally used 1.2-SNAPSHOT because it had a feature I thought I
wanted but ended up not using. I think it was running tests in
parallel.  I ended up writing my own concurrent test runner because I
needed it to work a certain way for the LocatorCache and TokenCache
tests.