### PR TITLE
make locator/token caches tunable

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/TokenCacheTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/cache/TokenCacheTest.java
@@ -29,7 +29,7 @@ public class TokenCacheTest {
     @Rule
     public RepeatingRule repeatedly = new RepeatingRule();
 
-    private final TokenCache cache = TokenCache.getInstance(60, SECONDS, 60, SECONDS);
+    private final TokenCache cache = TokenCache.getInstance(60, SECONDS);
 
     @Before
     public void setUp() {
@@ -76,8 +76,7 @@ public class TokenCacheTest {
             tokens.addAll(Token.getTokens(locator));
         }
         // And a cache with a fairly short timeout
-        TokenCache cache = TokenCache.getInstance(
-                100, MILLISECONDS, 100, MILLISECONDS);
+        TokenCache cache = TokenCache.getInstance(100, MILLISECONDS);
         // When I insert all the tokens into the cache
         tokens.forEach(cache::setTokenCurrent);
         // Then the cache reflects all of the entries


### PR DESCRIPTION
The hardcoded TTL values in these caches isn't long enough to handle a
heavy load of metrics. This makes the caches configurable and gives
them reasonable defaults based on observations from the load testing
I've been doing.

I also corrected some other, minor issues I found, including removing
the "expire after write" setting, which was causing entries to expire
that amount of time after they were created, regardless of the "expire
after access" setting.