### PR TITLE
add stats to discovery metrics

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/inputs/processors/DiscoveryWriter.java
@@ -39,6 +39,8 @@ public class DiscoveryWriter extends FunctionWithThreadPool<List<List<IMetric>>,
 
     private final List<DiscoveryIO> discoveryIOs = new ArrayList<DiscoveryIO>();
     private final Map<Class<? extends DiscoveryIO>, Meter> writeErrorMeters = new HashMap<Class<? extends DiscoveryIO>, Meter>();
+    private static final Meter locatorsWritten =
+            Metrics.meter(DiscoveryWriter.class, "Locators Written to Discovery");
     private static final Logger log = LoggerFactory.getLogger(DiscoveryWriter.class);
     private final boolean canIndex;
 
@@ -113,6 +115,7 @@ public class DiscoveryWriter extends FunctionWithThreadPool<List<List<IMetric>>,
                 // filter out the metrics that are current.
                 final List<IMetric> willIndex = DiscoveryWriter.condense(input);
 
+                locatorsWritten.mark(willIndex.size());
                 for (DiscoveryIO io : discoveryIOs) {
                     try {
                         io.insertDiscovery(willIndex);


### PR DESCRIPTION
The current emitted metrics only track batches of metrics processed by
discovery modules. The actual count of metrics isn't available. This
can cause some misleading graphs. A thousand batches being handled
here could mean one metric per batch or a thousand metrics per
batch. It can be important to know the difference.