### PR TITLE
ensure token caching in tests

### DIFF
--- a/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/TokenDiscoveryWriterTest.java
+++ b/blueflood-core/src/test/java/com/rackspacecloud/blueflood/inputs/processors/TokenDiscoveryWriterTest.java
@@ -169,6 +169,11 @@ public class TokenDiscoveryWriterTest {
         List<Token> actualTokensA = captor.getValue();
         assertEquals("Unexpected number of tokens", 5, actualTokensA.size());
         assertTrue(actualTokensA.containsAll(expectedTokens) && expectedTokens.containsAll(actualTokensA));
+
+        // Processing the same tokens twice in a row shouldn't produce another insertDiscovery call because the locator
+        // cache and token cache are used to remember that these things have already been processed.
+        tokenWriter.processTokens(batch).get();
+        verify(discovererA, times(1)).insertDiscovery(captor.capture());
     }
 
 }


### PR DESCRIPTION
I saw unexpected tokens being written under load. It seemed the caches
weren't preventing discovery writes as expected. This addition to the
test helps to verify that caching is working as expected.