### PR TITLE
Added manual GitHub action trigger to create release package.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: "Manual Release workflow"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version
+        required: true
+
+jobs:
+  tagged-release:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java-version: [ 8 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: 'maven'
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+          git remote -v
+      - name: Set version in env
+        run: |
+          version="${GITHUB_REF#refs/tags/}"
+          echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+      - name: Generate changelog
+        id: changelog
+        uses: metcalfc/changelog-generator@v0.4.4
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and deploy
+        run: |
+          pwd
+          git checkout -b release/${RELEASE_VERSION}
+          mvn -B release:prepare -DreleaseVersion=${RELEASE_VERSION} -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create pull request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "release/${{ github.event.inputs.version }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy Artifacts
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: /home/runner/work/blueflood/blueflood/blueflood-all/target/blueflood-all-${{ github.event.inputs.version }}-jar-with-dependencies.jar
+          tag: "blueflood-${{ github.event.inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,11 @@ jobs:
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
-          git remote -v
-      - name: Set version in env
-        run: |
-          version="${GITHUB_REF#refs/tags/}"
-          echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-      - name: Generate changelog
-        id: changelog
-        uses: metcalfc/changelog-generator@v0.4.4
-        with:
-          myToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and deploy
         run: |
           pwd
-          git checkout -b release/${RELEASE_VERSION}
-          mvn -B release:prepare -DreleaseVersion=${RELEASE_VERSION} -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
+          git checkout -b release/${{ github.event.inputs.version }}
+          mvn -B release:prepare -DreleaseVersion=${{ github.event.inputs.version }} -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create pull request
@@ -48,7 +38,7 @@ jobs:
         with:
           source_branch: "release/${{ github.event.inputs.version }}"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Copy Artifacts
+      - name: Create a new github release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -242,22 +242,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>3.0.0-M6</version>
       </plugin>
@@ -290,9 +274,6 @@
       <modules>
         <module>contrib/logstash-support</module>
       </modules>
-    </profile>
-    <profile>
-      <id>release</id>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,11 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.0-M6</version>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,22 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>3.0.0-M6</version>
       </plugin>
@@ -277,23 +293,6 @@
     </profile>
     <profile>
       <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
We need a trigger which can be used to create an automated release package for blueflood. We are using GitHub action with maven release plugin here to create the release package.
Maven release package helps in performing sequence of automated steps which will run tests on latest master code and then will create the tag which will have the release version which we specified when triggering the workflow. It will also increment the next snapshot version in all the moms wherever required.
A PR will be created as part of this workflow which will have the pom version changes of incremented snapshot version for new development.
Artifacts will be copied to the release package as well.