### PR TITLE
lower log level of closed idle connections

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/UserDefinedEventHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/inputs/handlers/UserDefinedEventHandler.java
@@ -30,7 +30,7 @@ public class UserDefinedEventHandler extends ChannelDuplexHandler {
             IdleStateEvent e = (IdleStateEvent) evt;
             if (e.state() == IdleState.READER_IDLE) {
 
-                log.info("Connection is closed as there is no inbound traffic for " +
+                log.debug("Connection is closed as there is no inbound traffic for " +
                         HTTP_CONNECTION_READ_IDLE_TIME_SECONDS + " seconds. Connection: [" + ctx.channel().toString() + "]");
                 ctx.close();
             }


### PR DESCRIPTION
This log line repeats regularly when running in production. It doesn't
need to be at info level.