### PR TITLE
move dependency retrieval to constructor

### DIFF
--- a/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
+++ b/blueflood-http/src/main/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandler.java
@@ -24,6 +24,10 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
     private static final Logger log = LoggerFactory.getLogger(HttpMetricsIndexHandler.class);
     private DiscoveryIO discoveryHandle;
 
+    public HttpMetricsIndexHandler() {
+        this.discoveryHandle = ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
+    }
+
     @Override
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) {
 
@@ -40,9 +44,6 @@ public class HttpMetricsIndexHandler implements HttpRequestHandler {
                     HttpResponseStatus.BAD_REQUEST);
             return;
         }
-
-        // default discoveryHandle to DISCOVERY_MODULES
-        discoveryHandle = (DiscoveryIO) ModuleLoader.getInstance(DiscoveryIO.class, CoreConfig.DISCOVERY_MODULES);
 
         if (discoveryHandle == null) {
             sendResponse(ctx, request, null, HttpResponseStatus.NOT_FOUND);


### PR DESCRIPTION
From history, it seems choosing the handler was at one point dependent
on details of the request. That reature (enum metrics iirc) was
removed from the project, but this line was left in the middle of the
request processing, when it really belongs in the constructor. There's
no reason to look up the handler for every request.