### PR TITLE
Removed sonatype dependency and using https for scm.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,16 +285,10 @@
     </license>
   </licenses>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <scm>
-    <connection>scm:git@github.com:rackerlabs/blueflood.git</connection>
-    <developerConnection>scm:git:git@github.com:rackerlabs/blueflood.git</developerConnection>
-    <url>git@github.com:rackerlabs/blueflood.git</url>
+    <connection>scm:https://github.com/rackerlabs/blueflood</connection>
+    <developerConnection>scm:git:https://github.com/rackerlabs/blueflood</developerConnection>
+    <url>https://github.com/rackerlabs/blueflood</url>
   </scm>
 
   <developers>


### PR DESCRIPTION
We don’t need sonatype dependency as parent right now and hence removing that. 
Changes the scm urls in pom from ssh connection to https which will be used in workflow.