### PR TITLE
changed token getting used to create PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: "release/${{ github.event.inputs.version }}"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_PR_WORKFLOW_TOKEN }}
       - name: Create a new github release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
As per github actions, when we craete a PR using default token, it does not run any checks and hence we are not able to merge the PR as checks are pending.
So we need to use some other token so that it is treated as normal PR and checks runs and we can merge the PR.
Below is the link for solution:
https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092