### PR TITLE
let Docker container start without initting

### DIFF
--- a/contrib/blueflood-docker/README.md
+++ b/contrib/blueflood-docker/README.md
@@ -20,6 +20,8 @@ Here's the list of ENV variables and their description.
 | ELASTICSEARCH_HOST | IP address of Elasticsearch node. (Required) | null |
 | DEBUG_JAVA | Whether to enable remote JVM debugging on port 5005 | false |
 | DEBUG_JAVA_SUSPEND | Whether to suspend JVM startup until a debugger attaches to the debug port | false |
+| INIT_CASSANDRA | Whether to run the init script to create the Cassandra schema at startup | true |
+| INIT_ELASTICSEARCH | Whether to run the init script to create the Elasticsearch indexes at startup | true |
 | MAX_ROLLUP_READ_THREADS | Maximum number of read threads participating in rolling up the metrics | 20 |
 | MAX_ROLLUP_WRITE_THREADS | Maximum number of write threads participating in rolling up the metrics | 5 |
 | MAX_CASSANDRA_CONNECTIONS | Maximum number of connections with each Cassandra node | 70 |

--- a/contrib/blueflood-docker/docker-entrypoint.sh
+++ b/contrib/blueflood-docker/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ -z $GRAPHITE_PREFIX ]] #default graphite prefix 
-then        
-export GRAPHITE_PREFIX=$HOSTNAME 
+if [[ -z $GRAPHITE_PREFIX ]] #default graphite prefix
+then
+export GRAPHITE_PREFIX=$HOSTNAME
 fi
 
 ######## If using BF with docker-compose / linking with C* and ES containers #######
@@ -17,62 +17,58 @@ export ELASTICSEARCH_HOST="$ELASTICSEARCH_PORT_9300_TCP_ADDR"
 fi
 
 ######## Connecting to Cassandra and loading Blueflood's schema #######
-CASSCOUNTER=0
-trap "exit" INT
-while [[ $CASSCOUNTER -lt 180 ]];  #Wait for 180 seconds for cassandra to get ready.
-do
-        let CASSCOUNTER=CASSCOUNTER+2
-	if nc -z $CASSANDRA_HOST 9042 > /dev/null || nc -z $CASSANDRA_HOST 9160 > /dev/null
-		then
-                echo "Connected to Cassandra at $CASSANDRA_HOST"
-		break
-	elif [[ $CASSCOUNTER == 180 ]]
-                then
-                echo "Error connecting to Cassandra at $CASSANDRA_HOST"
-                exit 1
-        else
-		echo "Waiting for Cassandra..."
-	fi 
-	sleep 2	
-done
+if [ "$INIT_CASSANDRA" != false ]; then
+  echo "Setting up initial Cassandra schema"
+  CASSCOUNTER=0
+  trap "exit" INT
+  while [[ $CASSCOUNTER -lt 180 ]];  #Wait for 180 seconds for cassandra to get ready.
+  do
+    let CASSCOUNTER=CASSCOUNTER+2
+    if nc -zw1 $CASSANDRA_HOST 9042 > /dev/null || nc -zw1 $CASSANDRA_HOST 9160 > /dev/null; then
+      echo "Connected to Cassandra at $CASSANDRA_HOST"
+      break
+    elif [[ $CASSCOUNTER == 180 ]]; then
+      echo "Error connecting to Cassandra at $CASSANDRA_HOST"
+      exit 1
+    else
+      echo "Waiting for Cassandra..."
+    fi
+    sleep 2
+  done
 
-export CASSANDRA_HOSTS="$CASSANDRA_HOST:9160"
-export CASSANDRA_BINXPORT_HOSTS="$CASSANDRA_HOST:9042"
-
-if [ -n "$ROLLUP_KEYSPACE" ] && [ "$ROLLUP_KEYSPACE" != "DATA" ]
-then
+  export CASSANDRA_HOSTS="$CASSANDRA_HOST:9160"
+  export CASSANDRA_BINXPORT_HOSTS="$CASSANDRA_HOST:9042"
+  if [ -n "$ROLLUP_KEYSPACE" ] && [ "$ROLLUP_KEYSPACE" != "DATA" ]; then
     sed -i "s/\"DATA\"/\"$ROLLUP_KEYSPACE\"/g" blueflood.cdl
+  fi
+
+  cqlsh $CASSANDRA_HOST -f blueflood.cdl
 fi
 
-cqlsh $CASSANDRA_HOST -f blueflood.cdl
-
 ######## Connecting to Elasticsearch #######
-ESCOUNTER=0
-trap "exit" INT
-while [[ $ESCOUNTER -lt 120 ]];  #Wait for 120 seconds for elasticsearch to get ready.
-do
-        let ESCOUNTER=ESCOUNTER+2
-        nc -z $ELASTICSEARCH_HOST 9300 > /dev/null
-        if [ $? == 0 ]
-                then
-                echo "Connected to Elasticsearch at $ELASTICSEARCH_HOST"
-                break
-        elif [[ $ESCOUNTER == 120 ]]
-                then
-                echo "Error connecting to Elasticsearch at $ELASTICSEARCH_HOST"
-                exit 2
-        else
-                echo "Waiting for ElasticSearch..."
-        fi
-        sleep 2 
-done
+if [ "$INIT_ELASTICSEARCH" != false ]; then
+  echo "Setting up Elasticsearch indexes"
+  ESCOUNTER=0
+  trap "exit" INT
+  while [[ $ESCOUNTER -lt 120 ]]; do #Wait for 120 seconds for elasticsearch to get ready.
+    let ESCOUNTER=ESCOUNTER+2
+    if nc -zw1 $ELASTICSEARCH_HOST 9200 > /dev/null || nc -zw1 $ELASTICSEARCH_HOST 9300 > /dev/null; then
+      echo "Connected to Elasticsearch at $ELASTICSEARCH_HOST"
+      break
+    elif [[ $ESCOUNTER == 120 ]]; then
+      echo "Error connecting to Elasticsearch at $ELASTICSEARCH_HOST"
+      exit 2
+    else
+      echo "Waiting for ElasticSearch..."
+    fi
+    sleep 2
+  done
 
-export ELASTICSEARCH_HOSTS="$ELASTICSEARCH_HOST:9300"
-export ELASTICSEARCH_HOST_FOR_REST_CLIENT="$ELASTICSEARCH_HOST:9200"
+  export ELASTICSEARCH_HOSTS="$ELASTICSEARCH_HOST:9300"
+  export ELASTICSEARCH_HOST_FOR_REST_CLIENT="$ELASTICSEARCH_HOST:9200"
 
-cd ES-Setup
-./init-es.sh -u $ELASTICSEARCH_HOST:9200 -r false
-cd ..
+  /ES-Setup/init-es.sh -u $ELASTICSEARCH_HOST:9200 -r false
+fi
 
 printenv > blueflood.conf
 


### PR DESCRIPTION
For a simple dev or demo environment, it's convenient to have the Blueflood container automatically initialize Cassandra and Elasticsearch for you when you start. The Docker image does that today. For anything like a realistic deployment, you'd never want this to happen automatically. This adds two env vars that will stop the initialization from running. It also cleans up the init code slightly. Specifically, it adds a 1-second timeout to the netcat probes that wait for Cassandra and Elasticsearch to come up, and it watches for Elasticsearch on either port 9200 (rest port) or 9300 (native transport port).