### PR TITLE
remove git from docker image

### DIFF
--- a/contrib/blueflood-docker/Dockerfile
+++ b/contrib/blueflood-docker/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER gaurav.bajaj@rackspace.com
 MAINTAINER ryan.stewart@rackspace.com
 
 RUN apt-get update && apt-get install -y \
-    git \
     netcat \
     python3 \
     python3-dev \


### PR DESCRIPTION
I don't know why git was part of the image here. It certainly doesn't seem to be required now. Removing it will save image build time and disk usage.