### PR TITLE
Added fix for failing integration test cases.

### DIFF
--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/cache/MetadataCacheIntegrationTest.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -93,6 +94,9 @@ public class MetadataCacheIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    @Ignore
+    //Ignoring this test case as it does not assert anything and modifies the static instance of MetaDataCache
+    //TODO Add some logical implentation for this test case.
     public void testCollisions() throws Exception {
         Locator loc1 = Locator.createLocatorFromPathComponents( getRandomTenantId(), "ac76PeGPSR", "entZ4MYd1W", "chJ0fvB5Ao", "mzord", "truncated"); // put unit of bytes
         Locator loc2 = Locator.createLocatorFromPathComponents( getRandomTenantId(), "acTmPLSgfv", "enLctkAMeN", "chQwBe5YiE", "mzdfw", "cert_end_in"); // put type of I

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
@@ -50,7 +50,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 
 @RunWith( JUnitParamsRunner.class )
-@Ignore
 public class ElasticIOIntegrationTest extends BaseElasticTest {
 
     protected ElasticIO elasticIO;

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
@@ -49,16 +49,21 @@ public class HttpEventsQueryHandlerIntegrationTest extends HttpIntegrationTestBa
     }
 
     @Test
-    @Ignore
-    // Ignoring this testcase because it is failing when run on new OS while passing on older version of OS.
     public void testHttpEventsQueryHandler_HappyCase() throws Exception {
         parameterMap = new HashMap<String, String>();
         parameterMap.put(Event.fromParameterName, String.valueOf(baseMillis - 86400000));
         parameterMap.put(Event.untilParameterName, String.valueOf(baseMillis + (86400000*3)));
-        HttpGet get = new HttpGet(getQueryEventsURI(tenantId));
-        HttpResponse response = client.execute(get);
-
-        String responseString = EntityUtils.toString(response.getEntity());
+        HttpResponse response = null;
+        String responseString = null;
+        for ( int i = 0; i < 5 ; i++ ) {
+            HttpGet get = new HttpGet(getQueryEventsURI(tenantId));
+            response = client.execute(get);
+            responseString = EntityUtils.toString(response.getEntity());
+            if (!responseString.equals("[]")) break;
+            //TODO Instead of using sleep here and any test cases we need to make use of some timeout like mechanism which polls the data for a certain timeout period.
+            Thread.sleep(1000);
+            System.out.println("Retrying to get data");
+        }
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
         Assert.assertFalse(responseString.equals("[]"));
         assertResponseHeaderAllowOrigin(response);

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMultiRollupsQueryHandlerIntegrationTest.java
@@ -42,9 +42,6 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
     private final String tenant_id = "333333";
 
     @Test
-    @Ignore
-    // Ignored this testcase because it is interfering with HttpRollupsQueryHandlerIntegrationTest.testHttpRollupsQueryHandler test which makes both of the testcases run result to fail.
-    // This behavior is intermittent because on newer OS it is failing but on older version these are working fine.
     public void testHttpMultiRollupsQueryHandler() throws Exception {
         // ingest and rollup metrics and verify CF points and elastic search indexes
         String postfix = getPostfix();
@@ -142,11 +139,12 @@ public class HttpMultiRollupsQueryHandlerIntegrationTest extends HttpIntegration
 
             JsonParser jsonParser = new JsonParser();
             JsonObject responseObject = jsonParser.parse( responseContent ).getAsJsonObject();
-
-            if( responseObject.getAsJsonArray( "metrics" ).size() == size )
+            JsonArray jsonArray = responseObject.getAsJsonArray("metrics").get(0).getAsJsonObject().getAsJsonArray("data");
+            if( responseObject.getAsJsonArray( "metrics" ).size() == size && jsonArray.size()!=0)
                 return responseObject;
 
-            Thread.currentThread().sleep( 5000 );
+            Thread.currentThread().sleep( 1000 );
+            System.out.println("Data not found. Will retry again!");
         }
 
         return null;

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpRollupsQueryHandlerIntegrationTest.java
@@ -39,9 +39,6 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
     private final String tenant_id = "333333";
 
     @Test
-    @Ignore
-    // Ignored this testcase because it is interfering with HttpMultiRollupsQueryHandlerIntegrationTest.testHttpMultiRollupsQueryHandler test which makes both of the testcases run result to fail.
-    // This behavior is intermittent because on newer OS it is failing but on older version these are working fine.
     public void testHttpRollupsQueryHandler() throws Exception {
 
         String postfix = getPostfix();
@@ -121,8 +118,7 @@ public class HttpRollupsQueryHandlerIntegrationTest extends HttpIntegrationTestB
             }
 
             System.out.println(String.format("Data for metric %s is not found, sleeping and retrying, payload: %s", metric_name, responseContent));
-            Thread.currentThread().sleep( 5000 );
-
+            Thread.currentThread().sleep( 1000 );
         }
         return null;
     }

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/utils/ElasticsearchTestServer.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/utils/ElasticsearchTestServer.java
@@ -94,6 +94,7 @@ public class ElasticsearchTestServer {
 
     public void startTlrx() {
         esSetup = new EsSetup();
+        esSetup.execute(EsSetup.deleteAll()); //Deletes all the index or documents before creating new ones.
         esSetup.execute(EsSetup.createIndex(ElasticIO.ELASTICSEARCH_INDEX_NAME_WRITE)
                 .withSettings(EsSetup.fromClassPath("index_settings.json"))
                 .withMapping("metrics", EsSetup.fromClassPath("metrics_mapping.json")));


### PR DESCRIPTION
There were 4 integration tests which are failing regularly. So Added following fix for those:
1. There was one poison test case `MetadataCacheIntegrationTest. testCollisions()` which was not asserting anything and was modifying static instance MetadataCache to use InMemoryDataIo object. This results in failure of few test cases. So, Ignoring this test case for now and will revisit it to add some meaningful implementation for the same.
2. Added a sleep and retry mechanism in two of the test cases as data was not present in first try.
3. ElasticIoIntegrationTest was failing in setup of elastic search when it tries to create metric_metadata index. So added one line of code to remove everything before creating any indexes.