### PR TITLE
add important logs to IT test output

### DIFF
--- a/blueflood-integration-tests/src/integration-test/resources/log4j.properties
+++ b/blueflood-integration-tests/src/integration-test/resources/log4j.properties
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.console.Threshold=WARN
 
 log4j.appender.F=org.apache.log4j.RollingFileAppender
 log4j.appender.F.File=tests.log
@@ -34,4 +38,4 @@ log4j.logger.org.apache.http.wire=INFO
 log4j.logger.org.apache.http.impl=INFO
 log4j.logger.org.apache.http.headers=INFO
 
-log4j.rootLogger=INFO, F
+log4j.rootLogger=INFO, F, console


### PR DESCRIPTION
Integration tests have only logged to file before, so in the event of some catastrophic failure, the error wasn't always readily apparent if you were only looking at the test output. For example, if your basic configuration is wrong, and it can't reach the database, you won't see the connection errors.

This makes WARN and higher logs go to the console, so they'll show directly in test output. Normally, you should never see anything extra from this logging. It should only show anything when something's really wrong.