### PR TITLE
ES test server is global

### DIFF
--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/ElasticIOIntegrationTest.java
@@ -54,15 +54,13 @@ public class ElasticIOIntegrationTest extends BaseElasticTest {
 
     protected ElasticIO elasticIO;
     protected ElasticTokensIO elasticTokensIO;
-    private static ElasticsearchTestServer elasticsearchTestServer;
 
     /**
      * Starts an embedded Elasticsearch that these tests can run against.
      */
     @BeforeClass
     public static void startElasticsearch() {
-        elasticsearchTestServer = new ElasticsearchTestServer();
-        elasticsearchTestServer.start();
+        ElasticsearchTestServer.getInstance().ensureStarted();
     }
 
     @Before
@@ -119,11 +117,6 @@ public class ElasticIOIntegrationTest extends BaseElasticTest {
 
         for (String typeToEmpty : typesToEmpty)
             deleteAllDocuments(typeToEmpty);
-    }
-
-    @AfterClass
-    public static void stopElasticsearch() {
-        elasticsearchTestServer.stop();
     }
 
     private void deleteAllDocuments(String typeToEmpty) throws URISyntaxException, IOException {


### PR DESCRIPTION
Starting a new Elasticsearch for every test that needs it is expensive in terms of time. This creates a global singleton for managing ES test servers so that ideally, every integration test can share the same server.

We still need to migrate all existing IT's to use this class so that we can easily transition to using TestContainers eventually (read: very soon).