### PR TITLE
recategorize two tests as integration tests

### DIFF
--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpAnnotationsEndToEndIntegrationTest.java
@@ -55,7 +55,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class HttpAnnotationsEndToEndTest {
+public class HttpAnnotationsEndToEndIntegrationTest {
     private static HttpIngestionService httpIngestionService;
     private static HttpClientVendor vendor;
     private static DefaultHttpClient client;

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/EventElasticSearchIOIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/EventElasticSearchIOIntegrationTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-public class EventElasticSearchIOTest {
+public class EventElasticSearchIOIntegrationTest {
     private static EventElasticSearchIO searchIO;
     private static EsSetup esSetup;
 


### PR DESCRIPTION
These tests are running as unit tests and starting an Elasticsearch server. To make the best use of ElasticsearchTestServer, we want all tests that use Elasticsearch to run in the same set of tests, so that we only start Elasticsearch once. This moves/renames those two tests so they run with all the other integration tests.