### PR TITLE
don't re-prepare statements

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DDelayedLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DDelayedLocatorIO.java
@@ -32,11 +32,16 @@ public class DDelayedLocatorIO implements DelayedLocatorIO {
     private static final String COLUMN1 = "column1";
     private static final String VALUE = "value";
 
-    private final PreparedStatement getValue;
-    private final PreparedStatement putValue;
+    private static PreparedStatement getValue;
+    private static PreparedStatement putValue;
 
     public DDelayedLocatorIO() {
+        if (getValue == null) {
+            prepareStatements();
+        }
+    }
 
+    private static void prepareStatements() {
         // create a generic select statement for retrieving from metrics_delayed_locator
         Select.Where select = QueryBuilder
                 .select()

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DLocatorIO.java
@@ -53,20 +53,22 @@ public class DLocatorIO implements LocatorIO {
     private static final String COLUMN1 = "column1";
     private static final String VALUE = "value";
 
-    private PreparedStatement getValue;
-    private PreparedStatement putValue;
+    private static PreparedStatement getValue;
+    private static PreparedStatement putValue;
 
     /**
      * Constructor
      */
     public DLocatorIO() {
-        createPreparedStatements();
+        if (getValue == null) {
+            createPreparedStatements();
+        }
     }
 
     /**
      * Create all prepared statements use in this class for metrics_locator
      */
-    private void createPreparedStatements()  {
+    private static void createPreparedStatements()  {
 
         // create a generic select statement for retrieving from metrics_locator
         Select.Where select = QueryBuilder

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetadataIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetadataIO.java
@@ -32,12 +32,13 @@ public class DMetadataIO implements MetadataIO {
 
     private final StringMetadataSerDes serDes = new StringMetadataSerDes();
 
-    private PreparedStatement getValue;
-    private PreparedStatement putValue;
+    private static PreparedStatement getValue;
+    private static PreparedStatement putValue;
 
     public DMetadataIO() {
-
-        createPreparedStatements();
+        if (getValue == null) {
+            createPreparedStatements();
+        }
     }
 
     private void createPreparedStatements() {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DMetricsCFPreparedStatements.java
@@ -56,41 +56,47 @@ public class DMetricsCFPreparedStatements {
 
     private static final DMetricsCFPreparedStatements INSTANCE = new DMetricsCFPreparedStatements();
 
-    protected final PreparedStatement insertToMetricsPreaggrFullStatement;
-    protected final PreparedStatement insertToMetricsPreaggr5MStatement;
-    protected final PreparedStatement insertToMetricsPreaggr20MStatement;
-    protected final PreparedStatement insertToMetricsPreaggr60MStatement;
-    protected final PreparedStatement insertToMetricsPreaggr240MStatement;
-    protected final PreparedStatement insertToMetricsPreaggr1440MStatement;
+    protected static PreparedStatement insertToMetricsPreaggrFullStatement;
+    protected static PreparedStatement insertToMetricsPreaggr5MStatement;
+    protected static PreparedStatement insertToMetricsPreaggr20MStatement;
+    protected static PreparedStatement insertToMetricsPreaggr60MStatement;
+    protected static PreparedStatement insertToMetricsPreaggr240MStatement;
+    protected static PreparedStatement insertToMetricsPreaggr1440MStatement;
 
-    protected final PreparedStatement selectFromMetricsPreaggrFullForRangeStatement;
-    protected final PreparedStatement selectFromMetricsPreaggr5MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsPreaggr20MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsPreaggr60MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsPreaggr240MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsPreaggr1440MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsPreaggrFullForRangeStatement;
+    protected static PreparedStatement selectFromMetricsPreaggr5MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsPreaggr20MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsPreaggr60MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsPreaggr240MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsPreaggr1440MForRangeStatement;
 
-    protected final PreparedStatement insertToMetricsBasicFullStatement;
-    protected final PreparedStatement insertToMetricsBasic5MStatement;
-    protected final PreparedStatement insertToMetricsBasic20MStatement;
-    protected final PreparedStatement insertToMetricsBasic60MStatement;
-    protected final PreparedStatement insertToMetricsBasic240MStatement;
-    protected final PreparedStatement insertToMetricsBasic1440MStatement;
+    protected static PreparedStatement insertToMetricsBasicFullStatement;
+    protected static PreparedStatement insertToMetricsBasic5MStatement;
+    protected static PreparedStatement insertToMetricsBasic20MStatement;
+    protected static PreparedStatement insertToMetricsBasic60MStatement;
+    protected static PreparedStatement insertToMetricsBasic240MStatement;
+    protected static PreparedStatement insertToMetricsBasic1440MStatement;
 
-    protected final PreparedStatement selectFromMetricsBasicFullForRangeStatement;
-    protected final PreparedStatement selectFromMetricsBasic5MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsBasic20MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsBasic60MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsBasic240MForRangeStatement;
-    protected final PreparedStatement selectFromMetricsBasic1440MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsBasicFullForRangeStatement;
+    protected static PreparedStatement selectFromMetricsBasic5MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsBasic20MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsBasic60MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsBasic240MForRangeStatement;
+    protected static PreparedStatement selectFromMetricsBasic1440MForRangeStatement;
 
-    protected Map<String, PreparedStatement> cfNameToSelectStatement;
-    protected Map<Granularity, PreparedStatement> preaggrGranToInsertStatement;
-    protected Map<Granularity, PreparedStatement> basicGranToInsertStatement;
+    protected static Map<String, PreparedStatement> cfNameToSelectStatement;
+    protected static Map<Granularity, PreparedStatement> preaggrGranToInsertStatement;
+    protected static Map<Granularity, PreparedStatement> basicGranToInsertStatement;
 
     private DMetricsCFPreparedStatements() {
         Session session = DatastaxIO.getSession();
+        // Only prepare statements once! The driver logs lots of complaints if you re-prepare statements.
+        if (insertToMetricsPreaggrFullStatement == null) {
+            prepareStatements(session);
+        }
+    }
 
+    private static void prepareStatements(Session session) {
         //
         // Preaggr insert statements
         //

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DShardStateIO.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/datastax/DShardStateIO.java
@@ -48,12 +48,13 @@ public class DShardStateIO implements ShardStateIO {
 
     private final SlotStateSerDes serDes = new SlotStateSerDes();
 
-    private PreparedStatement getShardState;
-    private PreparedStatement putShardState;
+    private static PreparedStatement getShardState;
+    private static PreparedStatement putShardState;
 
     public DShardStateIO() {
-
-        createPreparedStatements();
+        if (getShardState == null) {
+            createPreparedStatements();
+        }
     }
 
     private void createPreparedStatements() {


### PR DESCRIPTION
In integration tests, there are lots of logs from the Datastax driver about preparing statements that have already been prepared. This makes all prepared statements static, instead of instance, fields with a simple null check to prevent initializing them again, no matter how many instances are created of their containing classes.