### PR TITLE
prevent mbean re-registration

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/Instrumentation.java
@@ -63,7 +63,10 @@ public class Instrumentation implements InstrumentationMBean {
             final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             final String name = String.format("com.rackspacecloud.blueflood.io:type=%s", Instrumentation.class.getSimpleName());
             final ObjectName nameObj = new ObjectName(name);
-            mbs.registerMBean(new Instrumentation() { }, nameObj);
+            if (!mbs.isRegistered(nameObj)) {
+                mbs.registerMBean(new Instrumentation() {
+                }, nameObj);
+            }
         } catch (Exception exc) {
             log.error("Unable to register mbean for " + Instrumentation.class.getSimpleName(), exc);
         }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ScheduleContext.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/ScheduleContext.java
@@ -112,7 +112,7 @@ public class ScheduleContext implements IngestionContext, ScheduleContextMBean {
 
     private final ShardStateManager shardStateManager;
     private transient long scheduleTime = 0L;
-    
+
     /** these shards have been scheduled in the last 10 minutes. */
     private final Cache<Integer, Long> recentlyScheduledShards = CacheBuilder.newBuilder()
             .maximumSize(Constants.NUMBER_OF_SHARDS)
@@ -136,7 +136,7 @@ public class ScheduleContext implements IngestionContext, ScheduleContextMBean {
      * When you update one, you must update the other.
      */
     private final List<SlotKey> orderedScheduledSlots = new ArrayList<SlotKey>();
-    
+
     /** slots that are running are not scheduled. */
     private final Map<SlotKey, Long> runningSlots = new HashMap<SlotKey, Long>();
 
@@ -437,9 +437,9 @@ public class ScheduleContext implements IngestionContext, ScheduleContextMBean {
     // precondition: shard is unmanaged.
     public void addShard(int shard) {
         shardStateManager.add(shard);
-        lockManager.addShard(shard);    
+        lockManager.addShard(shard);
     }
-    
+
     // precondition: shard is managed.
     public void removeShard(int shard) {
         shardStateManager.remove(shard);
@@ -490,17 +490,14 @@ public class ScheduleContext implements IngestionContext, ScheduleContextMBean {
         return results;
     }
 
-    private boolean isMbeanRegistered = false;
     private synchronized void registerMBean() {
-
-        if (isMbeanRegistered) return;
-        isMbeanRegistered = true;
-
         try {
             final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             final String name = String.format("com.rackspacecloud.blueflood.io:type=%s", ScheduleContext.class.getSimpleName());
             final ObjectName nameObj = new ObjectName(name);
-            mbs.registerMBean(this, nameObj);
+            if (!mbs.isRegistered(nameObj)) {
+                mbs.registerMBean(this, nameObj);
+            }
         } catch (Exception exc) {
             log.error("Unable to register mbean for " + ScheduleContext.class.getSimpleName(), exc);
         }


### PR DESCRIPTION
Is this the right thing to do? In tests, these classes get instantiated multiple times, and it causes errors when they try to register themselves again. We can avoid that by checking if they're already registered.  It means we lose the notification from the logs if something were being mishandled in a real, runtime environment.