### PR TITLE
better elasticsearch failures

### DIFF
--- a/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
+++ b/blueflood-elasticsearch/src/main/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelper.java
@@ -547,7 +547,7 @@ public class ElasticsearchRestHelper {
             throw new IOException("Unable to reach Elasticsearch", lastException);
         }
         if (responseCode > 299) {
-            throw new IOException("Elasticsearch request failed");
+            throw new IOException("Elasticsearch request failed: " + responseBody);
         }
         return new ExecuteResponse(responseBody, responseCode);
     }

--- a/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
+++ b/blueflood-elasticsearch/src/test/java/com/rackspacecloud/blueflood/io/ElasticsearchRestHelperTest.java
@@ -85,7 +85,7 @@ public class ElasticsearchRestHelperTest {
       fail("Should have raised exception");
     } catch (Exception e) {
       assertThat(e, instanceOf(IOException.class));
-      assertThat(e.getMessage(), equalTo("Elasticsearch request failed"));
+      assertThat(e.getMessage(), equalTo("Elasticsearch request failed: default test response: foo bar baz"));
     }
   }
 


### PR DESCRIPTION
When Elasticsearch returns a non-2xx response code, ElasticsearchRestHelper throws an exception, but the reason for the error is lost. This adds the response body to the message. The body almost always has useful information in it, especially when the problem is because you're making some bad request or other while modifying the code.