### PR TITLE
migrate all ES tests to ES test server

### DIFF
--- a/blueflood-elasticsearch/pom.xml
+++ b/blueflood-elasticsearch/pom.xml
@@ -58,14 +58,6 @@
 
     <!-- testing dependencies -->
     <dependency>
-      <groupId>com.github.tlrx</groupId>
-      <artifactId>elasticsearch-test</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.9.2</version>

--- a/blueflood-http/pom.xml
+++ b/blueflood-http/pom.xml
@@ -84,14 +84,6 @@
       <version>1.3.2</version>
     </dependency>
 
-      <!-- testing dependencies -->
-    <dependency>
-      <groupId>com.github.tlrx</groupId>
-      <artifactId>elasticsearch-test</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 
 </project>

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerAnnotationIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/inputs/handlers/HttpHandlerAnnotationIntegrationTest.java
@@ -17,11 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.junit.AfterClass;
 import org.junit.Test;
 
 /**
@@ -180,19 +177,5 @@ public class HttpHandlerAnnotationIntegrationTest extends HttpIntegrationTestBas
 
     private ErrorResponse getErrorResponse(HttpResponse response) throws IOException {
         return new ObjectMapper().readValue(response.getEntity().getContent(), ErrorResponse.class);
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception{
-        URIBuilder builder = new URIBuilder().setScheme("http").setHost("127.0.0.1").setPort(9200).setPath("/events");
-        HttpDelete delete = new HttpDelete(builder.build());
-        HttpResponse response = client.execute(delete);
-        if(response.getStatusLine().getStatusCode() != 200)
-        {
-            System.out.println("Couldn't delete 'events' index after running tests.");
-        }
-        else {
-            System.out.println("Successfully deleted 'events' index after running tests.");
-        }
     }
 }

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpEventsQueryHandlerIntegrationTest.java
@@ -20,20 +20,12 @@ import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.types.Event;
 import java.util.Calendar;
 import java.util.HashMap;
-import org.apache.http.HttpEntity;
+
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -166,39 +158,6 @@ public class HttpEventsQueryHandlerIntegrationTest extends HttpIntegrationTestBa
             event.setData(String.format("[%s] %s %d", tenant, "Event data sample", i));
             event.setTags(String.format("[%s] %s %d", tenant, "Event tags sample", i));
             eventsSearchIO.insert(tenant, event.toMap());
-        }
-    }
-
-    /*
-    Once done testing, delete all of the records of the given type and index.
-    NOTE: Don't delete the index or the type, because that messes up the ES settings.
-     */
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        URIBuilder builder = new URIBuilder().setScheme("http")
-                .setHost("127.0.0.1").setPort(9200)
-                .setPath("/events/graphite_event/_query");
-
-        HttpEntityEnclosingRequestBase delete = new HttpEntityEnclosingRequestBase() {
-            @Override
-            public String getMethod() {
-                return "DELETE";
-            }
-        };
-        delete.setURI(builder.build());
-
-        String deletePayload = "{\"query\":{\"match_all\":{}}}";
-        HttpEntity entity = new NStringEntity(deletePayload, ContentType.APPLICATION_JSON);
-        delete.setEntity(entity);
-
-        HttpClient client = HttpClientBuilder.create().build();
-        HttpResponse response = client.execute(delete);
-        if(response.getStatusLine().getStatusCode() != 200)
-        {
-            System.out.println("Couldn't delete index after running tests.");
-        }
-        else {
-            System.out.println("Successfully deleted index after running tests.");
         }
     }
 }

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricNamesHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricNamesHandlerIntegrationTest.java
@@ -19,7 +19,6 @@ package com.rackspacecloud.blueflood.outputs.handlers;
 import static com.rackspacecloud.blueflood.io.AbstractElasticIO.ELASTICSEARCH_INDEX_NAME_READ;
 import static junit.framework.Assert.assertEquals;
 
-import com.github.tlrx.elasticsearch.test.EsSetup;
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.ElasticIO;
 import com.rackspacecloud.blueflood.outputs.formats.ErrorResponse;
@@ -33,18 +32,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,8 +52,6 @@ public class HttpMetricNamesHandlerIntegrationTest extends HttpIntegrationTestBa
 
     @BeforeClass
     public static void setup() throws Exception {
-        esSetup = new EsSetup();
-
         final List<IMetric> metrics = new ArrayList<>();
         for (int i = 0; i < numMetrics; i++) {
             long curMillis = baseMillis + i;
@@ -79,39 +68,6 @@ public class HttpMetricNamesHandlerIntegrationTest extends HttpIntegrationTestBa
         if(statusCode != 200) {
             System.out.println(String.format("Refresh for %s failed with status code: %d",
                     ELASTICSEARCH_INDEX_NAME_READ, statusCode));
-        }
-    }
-
-    /*
-    Once done testing, delete all of the records of the given type and index.
-    NOTE: Don't delete the index or the type, because that messes up the ES settings.
-     */
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        URIBuilder builder = new URIBuilder().setScheme("http")
-                .setHost("127.0.0.1").setPort(9200)
-                .setPath("/metric_metadata/metrics/_query");
-
-        HttpEntityEnclosingRequestBase delete = new HttpEntityEnclosingRequestBase() {
-            @Override
-            public String getMethod() {
-                return "DELETE";
-            }
-        };
-        delete.setURI(builder.build());
-
-        String deletePayload = "{\"query\":{\"match_all\":{}}}";
-        HttpEntity entity = new NStringEntity(deletePayload, ContentType.APPLICATION_JSON);
-        delete.setEntity(entity);
-
-        HttpClient client = HttpClientBuilder.create().build();
-        HttpResponse response = client.execute(delete);
-        if(response.getStatusLine().getStatusCode() != 200)
-        {
-            System.out.println("Couldn't delete index after running tests.");
-        }
-        else {
-            System.out.println("Successfully deleted index after running tests.");
         }
     }
 

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
@@ -66,7 +66,6 @@ public class HttpMetricsIndexHandlerIntegrationTest extends HttpIntegrationTestB
         }
 
         elasticIO.insertDiscovery(new ArrayList<IMetric>(metrics));
-        esSetup.client().admin().indices().prepareRefresh().execute().actionGet();
 
         metricsRW.insertMetrics(metrics);
     }

--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/outputs/handlers/HttpMetricsIndexHandlerIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.rackspacecloud.blueflood.outputs.handlers;
 
 import static junit.framework.Assert.assertEquals;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.rackspacecloud.blueflood.http.HttpIntegrationTestBase;
 import com.rackspacecloud.blueflood.io.IOContainer;
@@ -75,14 +76,16 @@ public class HttpMetricsIndexHandlerIntegrationTest extends HttpIntegrationTestB
         parameterMap = new HashMap<String, String>();
         parameterMap.put("query", metricPrefix + ".*");
         HttpGet get = new HttpGet(getQuerySearchURI(tenantId));
-        HttpResponse response = client.execute(get);
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            HttpResponse response = client.execute(get);
 
-        String responseString = EntityUtils.toString(response.getEntity());
-        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-        for (int i = 0; i < numMetrics; i++){
-            Assert.assertTrue(responseString.contains(String.format("{\"metric\":\"%s.%d\"}", metricPrefix, i)));
-        }
-        assertResponseHeaderAllowOrigin(response);
+            String responseString = EntityUtils.toString(response.getEntity());
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            for (int i = 0; i < numMetrics; i++){
+                Assert.assertTrue(responseString.contains(String.format("{\"metric\":\"%s.%d\"}", metricPrefix, i)));
+            }
+            assertResponseHeaderAllowOrigin(response);
+        });
     }
 
     @Test


### PR DESCRIPTION
This removes all uses of the Elasticsearch tlrx test library except for the one contained in ElasticsearchTestServer. Then everything that was using that library uses the new test class instead. This is so that we can easily switch to using test containers and also centrally manage the Elasticsearch version in tests.

I also cleaned up all of the teardown code I could find where an HTTP client was being used to delete data from Elasticsearch. In some cases, it was implemented wrong and was deleting entire indexes instead of just deleting documents out of the indexes. This was the cause of some of our spurious test failures. When the index was deleted, its mapping was lost, and the next test that used it created an index with a dynamic mapping.

The new reset code is safe and guarantees correct indexes for every test. It's run at the start of each test class either by the class itself, or because the class extends HttpIntegrationTestBase, which sets everything up for you.