### PR TITLE
adds native Cassandra schema init method

### DIFF
--- a/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/datastax/DCassandraUtilsIO.java
+++ b/blueflood-integration-tests/src/integration-test/java/com/rackspacecloud/blueflood/io/datastax/DCassandraUtilsIO.java
@@ -5,12 +5,42 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Select;
 import com.rackspacecloud.blueflood.test.CassandraUtilsIO;
-import com.rackspacecloud.blueflood.io.datastax.DatastaxIO;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * Utility class to provide some test methods existing tests use.
  */
 public class DCassandraUtilsIO implements CassandraUtilsIO {
+
+    /**
+     * Sets up the Blueflood keyspace in Cassandra. It relies on the "load.cdl" cql script that's referenced in many
+     * places. To avoid needing cqlsh, this does some dumb, line-based parsing of the script and assembles the lines
+     * into statements that it runs with the Cassandra driver. It should work fine, as long as nobody makes any crazy
+     * changes to that script. We can use this to ensure a schema exists for integration tests, for example.
+     */
+    public void initDb() throws Exception {
+        URL file = getClass().getResource("/cassandra/cli/load.cdl");
+        List<String> lines = Files.readAllLines(Paths.get(file.toURI()));
+        StringBuilder statementBuilder = new StringBuilder();
+        try (DatastaxIO io = new DatastaxIO(DatastaxIO.Keyspace.NO_KEYSPACE, false)) {
+            for (String line : lines) {
+                if (line.startsWith("--")) {
+                    // It's a comment
+                    continue;
+                }
+                statementBuilder.append(' ');
+                statementBuilder.append(line);
+                if (line.trim().endsWith(";")) {
+                    io.getInstanceSession().execute(statementBuilder.toString());
+                    statementBuilder.setLength(0);
+                }
+            }
+        }
+    }
 
     /**
      * Count the number of keys in the table.


### PR DESCRIPTION
So far, the only way to set up the Cassandra schema is by running the `load.cdl` script with a cqlsh client. This adds a method that will parse that script and run the statements through the Cassandra driver, so we can init the database purely from Java.